### PR TITLE
Fix responsibility for time from 'MoonPhase.js' to 'App.js'

### DIFF
--- a/react/src/App.js
+++ b/react/src/App.js
@@ -1,16 +1,29 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import './App.css';
 import MoonPhase from './MoonPhase';
 
 function App() {
+
+  const [currentTime, setCurrentTime] = useState(new Date());
+
   useEffect(() => {
       document.title = 'Dashboard';
       }, []);
-  const today = new Date();
+
+  useEffect(() => {
+      const timer = setInterval(() => {
+          setCurrentTime(new Date());
+          }, 1000);
+
+      return () => {
+      clearInterval(timer);
+      };
+      }, []);
+
 
   return (
       <div className="App">
-      <MoonPhase/>
+      <MoonPhase currentTime={currentTime}/>
 
       <header className="App-header">
       <h1>Dashboard</h1>

--- a/react/src/MoonPhase.js
+++ b/react/src/MoonPhase.js
@@ -1,12 +1,10 @@
 
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import { format, differenceInDays } from 'date-fns';
 import './MoonPhase.css';
 
-const MoonPhase = () => {
+const MoonPhase = ({ currentTime }) => {
   const [shadowStyle, setShadowStyle] = useState({width: '0%', isWaning: false});
-  const [currentTime, setCurrentTime] = useState(new Date());
 
   const formatLocalTime = (currentTime) => {
       const localTime = format(currentTime, "yyyy-MM-dd HH:mm:ss (O)");
@@ -25,16 +23,6 @@ const MoonPhase = () => {
     const width = isWaning ? (phasePercent - 50) * 2 : 100 - (phasePercent *2);
     return { width, isWaning };
   };
-
-  useEffect(() => {
-      const timer = setInterval(() => {
-          setCurrentTime(new Date());
-          }, 1000);
-
-      return () => {
-      clearInterval(timer);
-      };
-      }, []);
 
   useEffect(() => {
       const lunarAge = calculateLunarAge(currentTime);


### PR DESCRIPTION
Move time management responsibility from `MoonPhase.js` to `App.js` since there is a possiblity that other components for `App.js` also require time information. It should be managed at the same place.